### PR TITLE
Heed mastodon-alt-tl-show-status setting during status display

### DIFF
--- a/mastodon-alt.el
+++ b/mastodon-alt.el
@@ -152,7 +152,7 @@ display property to show the short url."
 
   (with-temp-buffer
     (insert string)
-     
+
     ;; WARNING: We get rid of display properties because it messes
     ;;          everything We could probably be less radical but
     ;;          it'll do for the time being.
@@ -485,7 +485,6 @@ String is filled with TOOT statistics (boosts, favs, replies and
 bookmark). When the TOOT is a reblog (boost), statistics from
 reblogged toots are returned."
 
-  (interactive)
   (when-let* ((toot (mastodon-alt-tl--status-toot toot)))
     (let* ((favourites-count (alist-get 'favourites_count toot))
            (favourited (equal 't (alist-get 'favourited toot)))

--- a/mastodon-alt.el
+++ b/mastodon-alt.el
@@ -483,44 +483,48 @@ This advisizes ORIG-FUN `mastodon-tl--more' and applies ARGS."
 
 String is filled with TOOT statistics (boosts, favs, replies and
 bookmark). When the TOOT is a reblog (boost), statistics from
-reblogged toots are returned."
+reblogged toots are returned.
 
-  (when-let* ((toot (mastodon-alt-tl--status-toot toot)))
-    (let* ((favourites-count (alist-get 'favourites_count toot))
-           (favourited (equal 't (alist-get 'favourited toot)))
-           (boosts-count (alist-get 'reblogs_count toot))
-           (boosted (equal 't (alist-get 'reblogged toot)))
-           (replies-count (alist-get 'replies_count toot))
-           (favourites (format "%s %s" favourites-count (mastodon-tl--symbol 'favourite)))
-           (boosts (format "%s %s" boosts-count (mastodon-tl--symbol 'boost)))
-           (replies (format "%s %s" replies-count (mastodon-tl--symbol 'reply)))
-           (bookmark (format "%s" (mastodon-tl--symbol 'bookmark)))
-           (bookmarked (equal 't (alist-get 'bookmarked toot)))
-           (status (concat
-                    (propertize favourites
-                                'favourited-p favourited
-                                'favourites-field t
-                                'favourites-count favourites-count
-                                'face (mastodon-alt-tl--status-face favourited favourites-count))
-                    (propertize " | " 'face (alist-get 'default mastodon-alt-tl-status-faces))
-                    (propertize boosts
-                                'boosted-p boosted
-                                'boosts-field t
-                                'boosts-count boosts-count
-                                'face (mastodon-alt-tl--status-face boosted boosts-count))
-                    (propertize " | " 'face (alist-get 'default mastodon-alt-tl-status-faces))
-                    (propertize replies
-                                'replies-field t
-                                'replies-count replies-count
-                                'face (mastodon-alt-tl--status-face nil replies-count))
-                    (propertize " | " 'face (alist-get 'default mastodon-alt-tl-status-faces))
-                    (propertize bookmark
-                                'bookmark-field t
-                                'face (mastodon-alt-tl--status-face bookmarked 0))))
-           (status (concat
-                    (propertize " " 'display `(space :align-to (- right ,(+ (length status) 2))))
-                    status)))
-      status)))
+To disable showing the status string at all, customize
+`mastodon-alt-tl-show-status'."
+
+  (when mastodon-alt-tl-show-status
+    (when-let* ((toot (mastodon-alt-tl--status-toot toot)))
+      (let* ((favourites-count (alist-get 'favourites_count toot))
+             (favourited (equal 't (alist-get 'favourited toot)))
+             (boosts-count (alist-get 'reblogs_count toot))
+             (boosted (equal 't (alist-get 'reblogged toot)))
+             (replies-count (alist-get 'replies_count toot))
+             (favourites (format "%s %s" favourites-count (mastodon-tl--symbol 'favourite)))
+             (boosts (format "%s %s" boosts-count (mastodon-tl--symbol 'boost)))
+             (replies (format "%s %s" replies-count (mastodon-tl--symbol 'reply)))
+             (bookmark (format "%s" (mastodon-tl--symbol 'bookmark)))
+             (bookmarked (equal 't (alist-get 'bookmarked toot)))
+             (status (concat
+                      (propertize favourites
+                                  'favourited-p favourited
+                                  'favourites-field t
+                                  'favourites-count favourites-count
+                                  'face (mastodon-alt-tl--status-face favourited favourites-count))
+                      (propertize " | " 'face (alist-get 'default mastodon-alt-tl-status-faces))
+                      (propertize boosts
+                                  'boosted-p boosted
+                                  'boosts-field t
+                                  'boosts-count boosts-count
+                                  'face (mastodon-alt-tl--status-face boosted boosts-count))
+                      (propertize " | " 'face (alist-get 'default mastodon-alt-tl-status-faces))
+                      (propertize replies
+                                  'replies-field t
+                                  'replies-count replies-count
+                                  'face (mastodon-alt-tl--status-face nil replies-count))
+                      (propertize " | " 'face (alist-get 'default mastodon-alt-tl-status-faces))
+                      (propertize bookmark
+                                  'bookmark-field t
+                                  'face (mastodon-alt-tl--status-face bookmarked 0))))
+             (status (concat
+                      (propertize " " 'display `(space :align-to (- right ,(+ (length status) 2))))
+                      status)))
+        status))))
 
 
 (defun mastodon-alt-tl--relative-time-details (orig-fun timestamp &optional current-time)


### PR DESCRIPTION
`mastodon-alt-tl-show-status` was defined but not used. Now it disables the status string rendering as mentioned in #6 

I also removed the `(interactive)` construct here because I don't see how this would be called interactively. Feel free to revert if that goes too far.