### PR TITLE
RFC: add github action for melpazoid

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,26 @@
+# melpazoid <https://github.com/riscy/melpazoid> build checks.
+
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Emacs
+        run: |
+          sudo apt-get -y install emacs || (sudo apt-get update && sudo apt-get -y install emacs)
+          emacs --version
+      - name: Ensure pip exists
+        run: |
+          command -v pip || sudo apt-get -y install python3-pip
+      - name: Install Melpazoid
+        run: |
+          ( cd ~/melpazoid && git checkout -- . && git pull --rebase ) || git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+          pip install ~/melpazoid 2>/dev/null
+      - name: Run melpazoid on mastodon-alt
+        env:
+          RECIPE: (mastodon-alt :repo "rougier/mastodon-alt" :fetcher github :files ("mastodon-alt*.el"))
+          EXIST_OK: false
+        run: echo $GITHUB_REF && env LOCAL_REPO="$GITHUB_WORKSPACE" make -C ~/melpazoid

--- a/mastodon-alt.el
+++ b/mastodon-alt.el
@@ -331,7 +331,7 @@ This should be ran just before an update."
   (remove-overlays (point-min) (point-max) 'mastodon-alt-update t)
   (let* ((overlay (make-overlay (point-min) (+ (point-min) 1) nil t))
          (width (- (window-width) 1))
-         (update (format-time-string " Update %H:%M "))
+         (update (format-time-string " Update %R "))
          (line (concat
                 (propertize "\n" 'face `(:foreground ,(face-background 'default)
                                          :extend t


### PR DESCRIPTION
Melpazoid is a simple elisp package linter that helps keep the project inline with a minimum amount of packaging best practices. With this PR, the project is already clean and passes CI, e.g. see for reference:

https://github.com/seanfarley/mastodon-alt/actions/runs/3885027075/jobs/6628366351

What this doesn't fix are linting settings such as indentation as seen here:

https://github.com/rougier/mastodon-alt/pull/7#issuecomment-1376956356

To fix that, the project would need to use something like [Eldev](https://github.com/doublep/eldev/), [Cask](https://github.com/cask/cask), etc

That's a big bikeshedding argument, though, so I leave it to the package maintainer :-) For information purposes, I only really have experience Eldev. If you want to add that kind of tool as a dev dependency is up to you, of course, but if you want to play around with it, I can add it to a branch for you.