### PR TITLE
Fix spoiler display with avatars

### DIFF
--- a/mastodon-alt.el
+++ b/mastodon-alt.el
@@ -674,6 +674,7 @@ DETAILED-P are the same as the original wrapped function
        ;; or if the image is short enough.
        (when (or (alist-get 'reblog toot)
                  (not mastodon-tl--show-avatars)
+                 (mastodon-tl--has-spoiler toot)
                  (< mastodon-media--avatar-height (frame-char-height)))
          "\n")
        (mastodon-alt-tl--toot-content toot)


### PR DESCRIPTION
A follow-up to #11. Removing the linebreak after the status line doesn't work well with the spoiler box:

![image](https://user-images.githubusercontent.com/21692287/235369209-afed1a7b-2484-4db7-9cab-820aaae1b660.png)

This fixes that issue.
