### PR TITLE
Fix for certain toots containing line breaks

### DIFF
--- a/mastodon-alt.el
+++ b/mastodon-alt.el
@@ -135,6 +135,14 @@ A negative value width means `window-width - width'"
   :type 'string
   :group 'mastodon-alt-tl)
 
+(defcustom mastodon-alt-tl-toot-refill t
+  "Whether to refill toot status text.
+
+Setting to `nil' fixes some problems with line breaks
+in e.g. itemized lists."
+  :type 'boolean
+  :group 'mastodon-alt-tl)
+
 (defun mastodon-alt-tl--shorten-url-format (host _name ext)
   "Format a shorten url using HOST and EXT.
 
@@ -659,7 +667,9 @@ applies TIMESTAMP and CURRENT-TIME."
           (t
            (concat
             "\n"
-            (string-fill content (- (window-width) 2))
+	    (if mastodon-alt-tl-toot-refill
+		(string-fill content (min (- (window-width) 2) fill-column))
+	      content )
             "\n\n")))))
 
 (defun mastodon-alt-tl--insert-status (_orig-fun toot _body author-byline action-byline


### PR DESCRIPTION
New customizable option `mastodon-alt-tl-toot-refill `, default value `t`, which determines if toot content is re-filled before being displayed in box. If set to `nil`, issues with displaying line breaks in e.g. Wordle scores are fixed -- although so far this works only in toots that are not boosts or inside Content-Warning boxes.

For example, when `mastodon-alt-tl-toot-refill ` is set to `t`, line breaks don't show in toots like the following:

![2024-02-24-212503_796x284_scrot](https://github.com/rougier/mastodon-alt/assets/1893566/f3aa8d35-83b2-49ec-9e5c-f5d3f249048d)

But when `mastodon-alt-tl-toot-refill ` is set to `nil`, we have nice behavior:

![2024-02-24-212423_558x479_scrot](https://github.com/rougier/mastodon-alt/assets/1893566/9388b690-5438-4329-beb1-ce69bdec123b)

Unfortunately, doesn't work in toots inside content warning or boost boxes  (yet):

![2024-02-24-213603_1043x706_scrot](https://github.com/rougier/mastodon-alt/assets/1893566/26982c0e-5beb-4376-83be-293e101076b1)

