### PR TITLE
Fix to stop toot status line overflowing

### DIFF
--- a/mastodon-alt.el
+++ b/mastodon-alt.el
@@ -143,6 +143,13 @@ in e.g. itemized lists."
   :type 'boolean
   :group 'mastodon-alt-tl)
 
+(defcustom mastodon-alt-tl-toot-status-align-space 2
+  "Parameter in display align-to for status line of toot.
+
+If status line overhangs, set to a larger integer, e.g. 8."
+  :type 'number
+  :group 'mastodon-alt-tl)
+
 (defun mastodon-alt-tl--shorten-url-format (host _name ext)
   "Format a shorten url using HOST and EXT.
 
@@ -531,7 +538,7 @@ To disable showing the status string at all, customize
                                   'bookmark-field t
                                   'face (mastodon-alt-tl--status-face bookmarked 0))))
              (status (concat
-                      (propertize " " 'display `(space :align-to (- right ,(+ (length status) 2))))
+                      (propertize " " 'display `(space :align-to (- right ,(+ (length status) mastodon-alt-tl-toot-status-align-space))))
                       status)))
         status))))
 


### PR DESCRIPTION
Added a customizable option `mastodon-alt-tl-toot-status-align-space`, default value 2, to avoid having to hard-code value in `mastodon-alt.el`. Setting this to a larger integer (5 or larger, 8 works for me) prevents the status line (i.e. the bottom-most part of the toot containing the number of Favorites, Boosts, Replies, and Bookmarks) from overflowing.

E.g. when this variable is set to `2`, the status line looks like this:

![2024-02-24-212752_1916x70_scrot](https://github.com/rougier/mastodon-alt/assets/1893566/8c5614ef-683f-4ecd-b60d-f0912c42ef43)

Setting it to `8` fixes the problem for me:

![2024-02-24-212813_1907x44_scrot](https://github.com/rougier/mastodon-alt/assets/1893566/7947b48e-7f56-4aba-982a-e5419d252ded)


*Made this a separate pull-request as asked for [here](https://github.com/rougier/mastodon-alt/pull/23#issuecomment-2133426302), just in case you decide your `make-box.el` fix is not ready to be deployed soon.*